### PR TITLE
Add databricks to pipfile and connection file

### DIFF
--- a/advanced-analytics-hybrid/streamlit/Pipfile
+++ b/advanced-analytics-hybrid/streamlit/Pipfile
@@ -11,6 +11,7 @@ pandas = "*"
 snowflake-connector-python = "==3.0.0"
 pandas-gbq = "==0.19.1"
 google = "*"
+databricks-sql-connector = "2.3.0"
 
 [dev-packages]
 

--- a/advanced-analytics-hybrid/streamlit/utils/connect.py
+++ b/advanced-analytics-hybrid/streamlit/utils/connect.py
@@ -5,6 +5,7 @@ import snowflake.connector
 import pandas as pd
 import streamlit as st
 import os as os
+from databricks import sql
 
 # Perform query.
 def get_data_from_warehouse(filename: str, warehouse: str) -> pd.DataFrame:
@@ -73,10 +74,30 @@ def get_data_from_warehouse(filename: str, warehouse: str) -> pd.DataFrame:
         query = query.replace('$2', f'`{dataset}`')
         df = pdgbq.read_gbq(query, credentials = service_account.Credentials.from_service_account_info(st.secrets["gcp_service_account"]))
         df.columns= df.columns.str.lower()
+    elif warehouse == 'databricks':
+        db_creds = st.secrets["databricks"]
+
+        databricks_server_hostname = db_creds["databricks_server_hostname"]
+        databricks_http_path = db_creds["databricks_http_path"]
+        databricks_token = db_creds["databricks_token"]
+        schema = db_creds["schema"]
+        catalog = db_creds["catalog"]
+
+        query = query.replace('$1', f'`{catalog}`')
+        query = query.replace('$2', f'`{schema}`')
+
+
+        with sql.connect(server_hostname = databricks_server_hostname,
+                        http_path       = databricks_http_path,
+                        access_token    = databricks_token) as connection:
+
+            with connection.cursor() as cursor:
+                cursor.execute(query)
+                result = cursor.fetchall()
+                df =  pd.DataFrame(result, columns=[x[0] for x in cursor.description])
+        df.columns= df.columns.str.lower()
 
     return df
-
-
 
 def download_data(query_file, data_file, warehouse):
     df = get_data_from_warehouse(query_file, warehouse)

--- a/advanced-analytics-mobile-accelerator/streamlit/Pipfile
+++ b/advanced-analytics-mobile-accelerator/streamlit/Pipfile
@@ -11,6 +11,7 @@ pandas = "*"
 snowflake-connector-python = "==3.0.0"
 pandas-gbq = "==0.19.1"
 google = "*"
+databricks-sql-connector = "2.3.0"
 
 [dev-packages]
 

--- a/advanced-analytics-mobile-accelerator/streamlit/utils/connect.py
+++ b/advanced-analytics-mobile-accelerator/streamlit/utils/connect.py
@@ -5,6 +5,7 @@ import snowflake.connector
 import pandas as pd
 import streamlit as st
 import os as os
+from databricks import sql
 
 # Perform query.
 def get_data_from_warehouse(filename: str, warehouse: str) -> pd.DataFrame:
@@ -73,10 +74,30 @@ def get_data_from_warehouse(filename: str, warehouse: str) -> pd.DataFrame:
         query = query.replace('$2', f'`{dataset}`')
         df = pdgbq.read_gbq(query, credentials = service_account.Credentials.from_service_account_info(st.secrets["gcp_service_account"]))
         df.columns= df.columns.str.lower()
+    elif warehouse == 'databricks':
+        db_creds = st.secrets["databricks"]
+
+        databricks_server_hostname = db_creds["databricks_server_hostname"]
+        databricks_http_path = db_creds["databricks_http_path"]
+        databricks_token = db_creds["databricks_token"]
+        schema = db_creds["schema"]
+        catalog = db_creds["catalog"]
+
+        query = query.replace('$1', f'`{catalog}`')
+        query = query.replace('$2', f'`{schema}`')
+
+
+        with sql.connect(server_hostname = databricks_server_hostname,
+                        http_path       = databricks_http_path,
+                        access_token    = databricks_token) as connection:
+
+            with connection.cursor() as cursor:
+                cursor.execute(query)
+                result = cursor.fetchall()
+                df =  pd.DataFrame(result, columns=[x[0] for x in cursor.description])
+        df.columns= df.columns.str.lower()
 
     return df
-
-
 
 def download_data(query_file, data_file, warehouse):
     df = get_data_from_warehouse(query_file, warehouse)

--- a/advanced-analytics-web-accelerator/streamlit/Pipfile
+++ b/advanced-analytics-web-accelerator/streamlit/Pipfile
@@ -11,6 +11,7 @@ pandas = "*"
 snowflake-connector-python = "==3.0.0"
 pandas-gbq = "==0.19.1"
 google = "*"
+databricks-sql-connector = "2.3.0"
 
 [dev-packages]
 

--- a/enhanced-consent-accelerator/streamlit/Pipfile
+++ b/enhanced-consent-accelerator/streamlit/Pipfile
@@ -11,6 +11,7 @@ pandas = "*"
 snowflake-connector-python = "==3.0.0"
 pandas-gbq = "==0.19.1"
 google = "*"
+databricks-sql-connector = "2.3.0"
 
 [dev-packages]
 

--- a/enhanced-consent-accelerator/streamlit/utils/connect.py
+++ b/enhanced-consent-accelerator/streamlit/utils/connect.py
@@ -5,6 +5,7 @@ import snowflake.connector
 import pandas as pd
 import streamlit as st
 import os as os
+from databricks import sql
 
 # Perform query.
 def get_data_from_warehouse(filename: str, warehouse: str) -> pd.DataFrame:
@@ -73,10 +74,30 @@ def get_data_from_warehouse(filename: str, warehouse: str) -> pd.DataFrame:
         query = query.replace('$2', f'`{dataset}`')
         df = pdgbq.read_gbq(query, credentials = service_account.Credentials.from_service_account_info(st.secrets["gcp_service_account"]))
         df.columns= df.columns.str.lower()
+    elif warehouse == 'databricks':
+        db_creds = st.secrets["databricks"]
+
+        databricks_server_hostname = db_creds["databricks_server_hostname"]
+        databricks_http_path = db_creds["databricks_http_path"]
+        databricks_token = db_creds["databricks_token"]
+        schema = db_creds["schema"]
+        catalog = db_creds["catalog"]
+
+        query = query.replace('$1', f'`{catalog}`')
+        query = query.replace('$2', f'`{schema}`')
+
+
+        with sql.connect(server_hostname = databricks_server_hostname,
+                        http_path       = databricks_http_path,
+                        access_token    = databricks_token) as connection:
+
+            with connection.cursor() as cursor:
+                cursor.execute(query)
+                result = cursor.fetchall()
+                df =  pd.DataFrame(result, columns=[x[0] for x in cursor.description])
+        df.columns= df.columns.str.lower()
 
     return df
-
-
 
 def download_data(query_file, data_file, warehouse):
     df = get_data_from_warehouse(query_file, warehouse)

--- a/enhanced-ecommerce-accelerator/streamlit/Pipfile
+++ b/enhanced-ecommerce-accelerator/streamlit/Pipfile
@@ -11,6 +11,7 @@ pandas = "*"
 snowflake-connector-python = "==3.0.0"
 pandas-gbq = "==0.19.1"
 google = "*"
+databricks-sql-connector = "2.3.0"
 
 [dev-packages]
 

--- a/enhanced-ecommerce-accelerator/streamlit/utils/connect.py
+++ b/enhanced-ecommerce-accelerator/streamlit/utils/connect.py
@@ -5,6 +5,7 @@ import snowflake.connector
 import pandas as pd
 import streamlit as st
 import os as os
+from databricks import sql
 
 # Perform query.
 def get_data_from_warehouse(filename: str, warehouse: str) -> pd.DataFrame:
@@ -73,10 +74,30 @@ def get_data_from_warehouse(filename: str, warehouse: str) -> pd.DataFrame:
         query = query.replace('$2', f'`{dataset}`')
         df = pdgbq.read_gbq(query, credentials = service_account.Credentials.from_service_account_info(st.secrets["gcp_service_account"]))
         df.columns= df.columns.str.lower()
+    elif warehouse == 'databricks':
+        db_creds = st.secrets["databricks"]
+
+        databricks_server_hostname = db_creds["databricks_server_hostname"]
+        databricks_http_path = db_creds["databricks_http_path"]
+        databricks_token = db_creds["databricks_token"]
+        schema = db_creds["schema"]
+        catalog = db_creds["catalog"]
+
+        query = query.replace('$1', f'`{catalog}`')
+        query = query.replace('$2', f'`{schema}`')
+
+
+        with sql.connect(server_hostname = databricks_server_hostname,
+                        http_path       = databricks_http_path,
+                        access_token    = databricks_token) as connection:
+
+            with connection.cursor() as cursor:
+                cursor.execute(query)
+                result = cursor.fetchall()
+                df =  pd.DataFrame(result, columns=[x[0] for x in cursor.description])
+        df.columns= df.columns.str.lower()
 
     return df
-
-
 
 def download_data(query_file, data_file, warehouse):
     df = get_data_from_warehouse(query_file, warehouse)


### PR DESCRIPTION
None of the accelerators currently support the databricks via streamlit anyway, but this adds the ability for them to easily do so in the future (especially for accelerators that don't have complex queries such as web or hybrid). As such it's not listed in any of the actual Streamlit files.

Tested on a web package one and the connection details all seem to work fine.